### PR TITLE
Fix duplicated deployment variable

### DIFF
--- a/azure-pipelines/build-pipeline-jp+kr.yml
+++ b/azure-pipelines/build-pipeline-jp+kr.yml
@@ -20,9 +20,10 @@ parameters:
 name: $(BuildDefinitionName)_$(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 variables:
-  buildType: 'staging'
   ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
     buildType: 'production'
+  ${{ else }}:  
+    buildType: 'staging'
 
 stages:
 - stage: Build

--- a/azure-pipelines/build-pipeline.yml
+++ b/azure-pipelines/build-pipeline.yml
@@ -21,9 +21,10 @@ parameters:
 name: $(BuildDefinitionName)_$(Year:yyyy).$(Month).$(DayOfMonth)$(Rev:.r)
 
 variables:
-  buildType: 'staging'
   ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
     buildType: 'production'
+  ${{ else }}:  
+    buildType: 'staging'
 
 stages:
 - stage: Build


### PR DESCRIPTION
After this fix there will still be a 'duplicate key' warning, because we are creating a runtime-accepted expression that the Azure DevOps server understands, but is not YAML-compliant.
More details: https://stackoverflow.com/a/71375693/162031