### PR TITLE
Remove html snippets when building react code

### DIFF
--- a/src/ext/MarkdownTransformer.ts
+++ b/src/ext/MarkdownTransformer.ts
@@ -1459,8 +1459,7 @@ export class MarkdownTransformer {
             case APIPlatform.React:
                 if (!PlatformDetectorRule.isTS(language) &&
                 !PlatformDetectorRule.isTSX(language) &&
-                 language !== "js" &&
-                 !PlatformDetectorRule.isHTML(language)) {
+                 language !== "js") {
                     return true;
                 }
 


### PR DESCRIPTION
I think that html code snippets are not viable for react documentation, so we can omit them which might result in a better markdown structure and readibility