### PR TITLE
docs(button-group): enable selection snippet for Blazor

### DIFF
--- a/doc/en/components/inputs/button-group.md
+++ b/doc/en/components/inputs/button-group.md
@@ -155,11 +155,8 @@ The sample below demonstrates the exposed `ButtonGroup` selection modes:
 `sample="/inputs/button-group/selection", height="170", alt="{Platform} Button Group Selection Example"`
 
 
-<!-- WebComponents, React -->
 A `ToggleButton` could be marked as selected via its `Selected` attribute or through the `ButtonGroup` `SelectedItems` attribute:
-<!-- end: WebComponents, React -->
 
-<!-- WebComponents, React -->
 ```html
 <igc-button-group selected-items='["bold"]'>
     <igc-toggle-button value="bold">
@@ -215,8 +212,6 @@ A `ToggleButton` could be marked as selected via its `Selected` attribute or thr
 
 > [!Note]
 > Setting `ToggleButton` `Value` attribute is mandatory for using the `SelectedItems` property of the `ButtonGroup`.
-
-<!-- end: WebComponents, React -->
 
 ### Size
 The `--ig-size` CSS custom property can be used to control the size of the button group.


### PR DESCRIPTION
Closes #1305 - Enable `selectedItems` code snippet example for Blazor task.