### PR TITLE
chore(Chat): Hide the Features sample for React...

### DIFF
--- a/doc/en/components/interactivity/chat.md
+++ b/doc/en/components/interactivity/chat.md
@@ -453,6 +453,8 @@ chat.addEventListener('igcMessageCreated', (e) => {
   console.log('Message:', e.detail);
 });
 ```
+
+`sample="/interactions/chat/features", height="900", alt="Web Components Chat Features"`
 <!-- end: WebComponents -->
 <!-- React -->
 ```tsx
@@ -462,7 +464,6 @@ chatRef.current.addEventListener('onMessageCreated', (e) => {
 });
 ```
 <!-- end: React -->
-`sample="/interactions/chat/features", height="900", alt="Web Components Chat Features"`
 
 ## Styling
 


### PR DESCRIPTION
... due to an issue with the markdown renderer which happens in the samples browser only.