### PR TITLE
fix(themes,blazor): overview themes listing and unavailable API

### DIFF
--- a/doc/en/components/themes/overview.md
+++ b/doc/en/components/themes/overview.md
@@ -29,6 +29,18 @@ Here's the complete list of all bundled themes and their path:
 | **Indigo**      | Dark    | igniteui-react-grids/grids/themes/dark/indigo.css     |
 <!-- end: React -->
 
+<!-- Blazor -->
+| Name        | Variant | Location                                          |
+| ----------- | ------- | ------------------------------------------------- |
+| **Bootstrap**   | Light   | _content/IgniteUI.Blazor/themes/light/bootstrap.css |
+| **Material**    | Light   | _content/IgniteUI.Blazor/themes/light/material.css  |
+| **Fluent**      | Light   | _content/IgniteUI.Blazor/themes/light/fluent.css    |
+| **Indigo**      | Light   | _content/IgniteUI.Blazor/themes/light/indigo.css    |
+| **Bootstrap**   | Dark    | _content/IgniteUI.Blazor/themes/dark/bootstrap.css  |
+| **Material**    | Dark    | _content/IgniteUI.Blazor/themes/dark/material.css   |
+| **Fluent**      | Dark    | _content/IgniteUI.Blazor/themes/dark/fluent.css     |
+| **Indigo**      | Dark    | _content/IgniteUI.Blazor/themes/dark/indigo.css     |
+<!-- end: Blazor -->
 
 <!-- WebComponents -->
 | Name        | Variant | Location                                          |
@@ -63,6 +75,8 @@ This only tells components to switch their internal styles to the desired theme,
 
 <!-- end: WebComponents -->
 
+<!-- React, WebComponents -->
 ## API References
 
 - `ConfigureTheme`
+<!-- end: React, WebComponents -->

--- a/doc/jp/components/themes/overview.md
+++ b/doc/jp/components/themes/overview.md
@@ -30,6 +30,19 @@ _language: ja
 | **Indigo**      | ダーク    | igniteui-react-grids/grids/themes/dark/indigo.css     |
 <!-- end: React -->
 
+<!-- Blazor -->
+| 名前        | バリアント | 場所                                          |
+| ----------- | ------- | ------------------------------------------------- |
+| **Bootstrap**   | ライト   | _content/IgniteUI.Blazor/themes/light/bootstrap.css |
+| **Material**    | ライト   | _content/IgniteUI.Blazor/themes/light/material.css  |
+| **Fluent**      | ライト   | _content/IgniteUI.Blazor/themes/light/fluent.css    |
+| **Indigo**      | ライト   | _content/IgniteUI.Blazor/themes/light/indigo.css    |
+| **Bootstrap**   | ダーク    | _content/IgniteUI.Blazor/themes/dark/bootstrap.css  |
+| **Material**    | ダーク    | _content/IgniteUI.Blazor/themes/dark/material.css   |
+| **Fluent**      | ダーク    | _content/IgniteUI.Blazor/themes/dark/fluent.css     |
+| **Indigo**      | ダーク    | _content/IgniteUI.Blazor/themes/dark/indigo.css     |
+<!-- end: Blazor -->
+
 
 <!-- WebComponents -->
 | 名前        | バリアント | 場所                                        |
@@ -64,6 +77,8 @@ configureTheme("material");
 
 <!-- end: WebComponents -->
 
+<!-- React, WebComponents -->
 ## API リファレンス
 
 - `ConfigureTheme`
+<!-- end: React, WebComponents -->


### PR DESCRIPTION
Current state of the topic is quite broken with missing section content and API link to `ConfigureTheme` that I don't think is made available to Blazor at this point:
<img width="2816" height="1442" alt="image" src="https://github.com/user-attachments/assets/a0231fed-49cf-4772-bfb0-aba6e8585d15" />
https://www.infragistics.com/products/ignite-ui-blazor/blazor/components/themes/overview

This _**ONLY**_ fixes the current state, besides it needing much more work.
