### PR TITLE
docs(ai): fix Blazor docs, package names, and incorrect notes across AI docs

### DIFF
--- a/doc/en/components/ai/ai-assisted-development-overview.md
+++ b/doc/en/components/ai/ai-assisted-development-overview.md
@@ -1,6 +1,6 @@
 ﻿---
 title: AI-Assisted Development with Ignite UI - {ProductName}
-_description: Configure Agent Skills, the Ignite UI MCP server, and the Theming MCP server in your Angular, React, Blazor, or Web Components project with a single command — npx igniteui-cli ai-config. Grounds GitHub Copilot, Cursor, Claude Desktop, Claude Code, and JetBrains AI Assistant in correct Ignite UI APIs.
+_description: Configure Agent Skills, the Ignite UI MCP server, and the Theming MCP server in your Angular, React, Blazor, or Web Components project with a single command - npx igniteui-cli ai-config. Grounds GitHub Copilot, Cursor, Claude Desktop, Claude Code, and JetBrains AI Assistant in correct Ignite UI APIs.
 _keywords: {Platform}, {ProductName}, Infragistics, MCP, Model Context Protocol, Ignite UI MCP server, Ignite UI Theming MCP, Agent Skills, AI, agent, Copilot, Cursor, Claude Code, ai-config
 _language: en
 _license: MIT
@@ -14,7 +14,7 @@ mentionedTypes: []
 
 # AI-Assisted Development with Ignite UI
 
-{ProductName} provides a complete AI toolchain - Agent Skills, the Ignite UI CLI MCP server, the Ignite UI Theming MCP server and the MAKER MCP server - that grounds AI coding assistants in correct component APIs, import paths, and design tokens. Agent Skills are developer-owned instruction packages that define how AI agents use Ignite UI in a specific project. The CLI MCP server (`@igniteui/mcp-server`) exposes Ignite UI CLI scaffolding, component management, and documentation tools to the active AI agent session via the Model Context Protocol. The Theming MCP server (`igniteui-theming`) exposes the Ignite UI Theming Engine as queryable agent context. The MAKER MCP (`@igniteui/maker-mcp`) is a multi-agent AI orchestration MCP server from Infragistics that decomposes complex tasks into validated, executable step plans using a consensus-based voting algorithm across multiple AI agents. Skills, CLI MCP and Theming MCP - all three are configured by a single command: `npx igniteui-cli ai-config`
+{ProductName} provides a complete AI toolchain - Agent Skills, the Ignite UI CLI MCP server, the Ignite UI Theming MCP server and the MAKER MCP server - that grounds AI coding assistants in correct component APIs, import paths, and design tokens. Agent Skills are developer-owned instruction packages that define how AI agents use Ignite UI in a specific project. The CLI MCP server (`igniteui-cli`) exposes Ignite UI CLI scaffolding, component management, and documentation tools to the active AI agent session via the Model Context Protocol. The Theming MCP server (`igniteui-theming`) exposes the Ignite UI Theming Engine as queryable agent context. The MAKER MCP (`@igniteui/maker-mcp`) is a multi-agent AI orchestration MCP server from Infragistics that decomposes complex tasks into validated, executable step plans using a consensus-based voting algorithm across multiple AI agents. Skills, CLI MCP and Theming MCP - all three are configured by a single command: `npx igniteui-cli ai-config`
 
 The MCP servers and Agent Skills serve different purposes and have different prerequisites:
  
@@ -39,25 +39,37 @@ npx igniteui-cli ai-config
 > [!IMPORTANT]
 > Without a version pin, `npx` may pull an older CLI version that does not recognize the `ai-config` subcommand and will instead launch an interactive project-creation prompt, scaffolding a new project inside your existing one. Make sure that you have installed CLI version 16.x.
 
+<!-- Blazor -->
+> [!NOTE]
+> For Blazor, `ai-config` detects your project by looking for a `.csproj` or `.sln` file. The `IgniteUI.Blazor` NuGet package does not need to be installed.
+<!-- end: Blazor -->
+
+If `ai-config` cannot detect the framework from your project files, it prompts you to select one - so the command works even from a project where no Ignite UI package is installed yet.
+
 After the command finishes, start the MCP servers in your AI client. The servers are configured but not yet running - the client needs to launch each server before its tools are available to the agent.
 
 ### What to Expect
  
 If Ignite UI is **not** installed in the project:
- 
-```
-Ignite UI MCP servers configured in .vscode/mcp.json
-No AI skill files found. Make sure packages are installed (npm install) and your Ignite UI packages are up-to-date.
-```
+
+<!-- Angular, React, WebComponents -->
+> [!NOTE]
+> Ignite UI MCP servers configured in `.vscode/mcp.json`
+> No AI skill files found. Make sure packages are installed (`npm install`) and your Ignite UI packages are up-to-date.
+<!-- end: Angular, React, WebComponents -->
+
+<!-- Blazor -->
+> [!NOTE]
+> Ignite UI MCP servers configured in `.vscode/mcp.json`
+<!-- end: Blazor -->
  
 The MCP servers are ready to use. Skills will be added automatically the next time you run `ai-config` after installing Ignite UI.
  
 If Ignite UI **is** installed in the project:
  
-```
-Ignite UI MCP servers configured in .vscode/mcp.json
-Agent Skills copied to .claude/skills/
-```
+> [!NOTE]
+> Ignite UI MCP servers configured in `.vscode/mcp.json`
+> Agent Skills copied to `.claude/skills/`
  
 Both the MCP servers and Skills are configured.
 
@@ -84,7 +96,7 @@ Open **Settings → Tools → AI Assistant → Model Context Protocol (MCP)**. C
 Quit and relaunch Claude Desktop. The servers start automatically on launch.
 
 ### Install Ignite UI and Add Skills Later
- 
+
 If you ran `ai-config` without Ignite UI installed and want to add Skills, install the Ignite UI package for your framework and re-run the command:
  
 <!-- Angular -->
@@ -116,16 +128,13 @@ npx igniteui-cli@latest ai-config
 
 <!-- Blazor -->
 
-> [!Note]
-> For Blazor, the `ai-config` command is currently not available. Install the skills using the GitHub CLI:
-
 ```bash
-gh skill install IgniteUI/igniteui-blazor
+npx igniteui-cli@latest ai-config
 ```
 
 <!-- end: Blazor -->
 
-The command detects that Skills are now available and copies them. The MCP server entries in `.vscode/mcp.json` are left unchanged (already up-to-date)
+The command detects that Skills are now available and copies them. The MCP server entries in `.vscode/mcp.json` are left unchanged (already up-to-date).
 
 ## The AI Toolchain at a Glance
 
@@ -151,13 +160,13 @@ For full setup instructions and IDE wiring, see [Agent Skills](skills.md).
 
 The Ignite UI CLI MCP server (`igniteui-cli`) is an MCP server maintained by Infragistics that exposes Ignite UI CLI scaffolding and documentation tools to the active AI agent session. Once connected, the AI assistant can create Angular, React, Blazor or Web Components projects, add and modify Ignite UI components, and answer documentation and API questions - all through natural-language prompts in the chat session.
 
-The CLI MCP server is configured via `npx` without a global install:
+The CLI MCP server runs via `npx` without a global install:
 
 ```bash
-npx igniteui-cli ai-config
+npx -y igniteui-cli mcp
 ```
 
-The server connects to VS Code with GitHub Copilot, Cursor, Claude Desktop, Claude Code, JetBrains AI Assistant, and any other MCP-compatible client that supports STDIO transport. The exact configuration format differs by client - see the CLI MCP setup guides below.
+Use `ai-config` to write the MCP configuration for your AI client automatically. The server connects to VS Code with GitHub Copilot, Cursor, Claude Desktop, Claude Code, JetBrains AI Assistant, and any other MCP-compatible client that supports STDIO transport. The exact configuration format differs by client - see [CLI MCP](cli-mcp.md) for the full setup guide.
 
 It does not generate code autonomously - it exposes tools to the AI agent, which invokes them in response to developer prompts.
 
@@ -221,14 +230,29 @@ ig ai-config
 > The `npx igniteui-cli` and `ig` forms do not register the `@angular/cli` MCP server. Use the Angular Schematics command above if you want all three servers configured in a single step.
 <!-- end: Angular -->
 
-<!-- Angular, React, Web Components -->
+<!-- Angular, React, WebComponents -->
 > [!NOTE]
 > The command requires Ignite UI packages to be installed in your project (`npm install`). If no skill files are found, make sure your packages are up-to-date.
-<!-- end: Angular, React, Web Components -->
+<!-- end: Angular, React, WebComponents -->
+
+<!-- Blazor -->
+> [!NOTE]
+> For Blazor, `ai-config` detects your project via `.csproj` or `.sln`. If no project file is found, the command prompts you to select a framework.
+<!-- end: Blazor -->
 
 ### Step 1 - Load Agent Skills
 
-Copy the Ignite UI Skill package for your framework into your project's agent discovery path. The Skill package ships with the library in `node_modules/igniteui-{framework}/skills/`. Wire it to your IDE using the persistent setup for your client.
+Copy the Ignite UI Skill package for your framework into your project's agent discovery path.
+
+<!-- Angular, React, WebComponents -->
+The Skill package ships with the library in `node_modules/igniteui-{framework}/skills/`.
+<!-- end: Angular, React, WebComponents -->
+
+<!-- Blazor -->
+The Skill package for Blazor is copied automatically when `ai-config` detects a `.csproj` or `.sln` file in your project root.
+<!-- end: Blazor -->
+
+Wire it to your IDE using the persistent setup for your client.
 
 See [Agent Skills](skills.md) for the complete setup.
 
@@ -268,9 +292,24 @@ For the full setup guide, including VS Code, GitHub, Cursor, Claude Desktop, Cla
 
 Add the `igniteui-theming` entry to the same MCP configuration file, alongside `igniteui-cli`:
 
+**VS Code (`.vscode/mcp.json`):**
+
 ```json
 {
   "servers": {
+    "igniteui-theming": {
+      "command": "npx",
+      "args": ["-y", "igniteui-theming", "igniteui-theming-mcp"]
+    }
+  }
+}
+```
+
+**Cursor, Claude Desktop, Claude Code, JetBrains, and other MCP clients:**
+
+```json
+{
+  "mcpServers": {
     "igniteui-theming": {
       "command": "npx",
       "args": ["-y", "igniteui-theming", "igniteui-theming-mcp"]

--- a/doc/en/components/ai/ai-assisted-development-overview.md
+++ b/doc/en/components/ai/ai-assisted-development-overview.md
@@ -54,13 +54,13 @@ If Ignite UI is **not** installed in the project:
 
 <!-- Angular, React, WebComponents -->
 > [!NOTE]
-> Ignite UI MCP servers configured in `.vscode/mcp.json`
+> Ignite UI MCP servers configured for your selected clients
 > No AI skill files found. Make sure packages are installed (`npm install`) and your Ignite UI packages are up-to-date.
 <!-- end: Angular, React, WebComponents -->
 
 <!-- Blazor -->
 > [!NOTE]
-> Ignite UI MCP servers configured in `.vscode/mcp.json`
+> Ignite UI MCP servers configured for your selected clients
 <!-- end: Blazor -->
  
 The MCP servers are ready to use. Skills will be added automatically the next time you run `ai-config` after installing Ignite UI.
@@ -68,8 +68,8 @@ The MCP servers are ready to use. Skills will be added automatically the next ti
 If Ignite UI **is** installed in the project:
  
 > [!NOTE]
-> Ignite UI MCP servers configured in `.vscode/mcp.json`
-> Agent Skills copied to `.claude/skills/`
+> Ignite UI MCP servers configured for your selected clients
+> Agent Skills copied to your selected agents' skills directories
  
 Both the MCP servers and Skills are configured.
 
@@ -134,7 +134,7 @@ npx igniteui-cli@latest ai-config
 
 <!-- end: Blazor -->
 
-The command detects that Skills are now available and copies them. The MCP server entries in `.vscode/mcp.json` are left unchanged (already up-to-date).
+The command detects that Skills are now available and copies them. The MCP configuration files for your selected clients are left unchanged (already up-to-date).
 
 ## The AI Toolchain at a Glance
 
@@ -210,7 +210,7 @@ The `ai-config` command configures MCP servers, copies framework-specific skill 
 ng generate @igniteui/angular-schematics:ai-config
 ```
 
-This also registers the `@angular/cli` MCP server in `.vscode/mcp.json` alongside the Ignite UI servers.
+This also registers the `@angular/cli` MCP server alongside the Ignite UI servers for your selected clients.
 <!-- end: Angular -->
 
 **Using the Ignite UI CLI:**

--- a/doc/en/components/ai/ai-assisted-development-overview.md
+++ b/doc/en/components/ai/ai-assisted-development-overview.md
@@ -1,6 +1,6 @@
 ﻿---
 title: AI-Assisted Development with Ignite UI - {ProductName}
-_description: Configure Agent Skills, the Ignite UI MCP server, and the Theming MCP server in your Angular, React, Blazor, or Web Components project with a single command - npx igniteui-cli ai-config. Grounds GitHub Copilot, Cursor, Claude Desktop, Claude Code, and JetBrains AI Assistant in correct Ignite UI APIs.
+_description: Configure Agent Skills, the Ignite UI MCP server, and the Theming MCP server in your Angular, React, Blazor, or Web Components project with a single command - npx igniteui-cli@latest ai-config. Grounds GitHub Copilot, Cursor, Claude Desktop, Claude Code, and JetBrains AI Assistant in correct Ignite UI APIs.
 _keywords: {Platform}, {ProductName}, Infragistics, MCP, Model Context Protocol, Ignite UI MCP server, Ignite UI Theming MCP, Agent Skills, AI, agent, Copilot, Cursor, Claude Code, ai-config
 _language: en
 _license: MIT

--- a/doc/en/components/ai/cli-mcp.md
+++ b/doc/en/components/ai/cli-mcp.md
@@ -22,7 +22,7 @@ last_updated: "2026-04-24"
 
 Ignite UI CLI MCP gives AI assistants direct access to Ignite UI CLI project scaffolding, component generation, project modification, and documentation-aware workflows through chat or agent mode. The server works alongside [Ignite UI Theming MCP](./theming-mcp.md). CLI MCP handles project and component workflows while Theming MCP handles palettes, themes, tokens, and styling. Most teams connect both servers in the same AI client session.
 
-The recommended setup path is to start with Ignite UI CLI first. That path creates the project, installs the required packages, and writes the initial MCP configuration for VS Code. You can also start from an empty folder and let the assistant create the project through MCP, or connect MCP to a project that already exists.
+The recommended setup path is to start with Ignite UI CLI first. That path creates the project, installs the required packages, and prompts you to choose which AI clients and agents to configure. You can also start from an empty folder and let the assistant create the project through MCP, or connect MCP to a project that already exists.
 
 **Example prompts to try once connected:**
 
@@ -70,19 +70,19 @@ npx -y igniteui-cli mcp
 You can start with Ignite UI CLI MCP in three ways:
 
 > **Recommended - CLI first**
-> Create the project with Ignite UI CLI first by using `ig new` or the matching `npx --package igniteui-cli igniteui new` command. This is the easiest setup because Ignite UI CLI scaffolds the project, installs the required packages, and writes `.vscode/mcp.json` for VS Code automatically. After that, you only need to review the generated MCP configuration and open the project in your AI client.
+> Create the project with Ignite UI CLI first by using `ig new` or the matching `npx --package igniteui-cli igniteui new` command. This is the easiest setup because Ignite UI CLI scaffolds the project, installs the required packages, and prompts you to choose which AI clients to configure for MCP and which agents to set up skill files for. After that, you only need to review the generated configuration and open the project in your AI client.
 
 > **Empty folder**
 > Start with a completely empty folder, add the MCP configuration manually, and then ask the assistant to create the project through chat. This path is useful when you want MCP to drive the project creation flow from the beginning instead of running the CLI yourself first.
 
 > **Existing project**
-> Add MCP configuration to a project you already have and continue working in the current codebase. Run `ig ai-config` (or `ng generate @igniteui/angular-schematics:ai-config` for Angular projects) to write `.vscode/mcp.json` and copy the Agent Skills into your project automatically. For other AI clients, copy the server entries from the client-specific sections below.
+> Add MCP configuration to a project you already have and continue working in the current codebase. Run `ig ai-config` (or `ng generate @igniteui/angular-schematics:ai-config` for Angular projects) to write MCP configuration for your selected AI clients and copy the Agent Skills into your project. The command prompts you to choose which clients and agents to configure.
 
 All three paths use the same MCP servers. The difference is only how the project is prepared before you start prompting:
 
 - in the **CLI-first** path, Ignite UI CLI creates the project and prepares the first MCP configuration for you
 - in the **empty-folder** path, you create the MCP configuration first and let the assistant create the project after that
-- in the **existing-project** path, run `ig ai-config` to write `.vscode/mcp.json` and copy the Agent Skills automatically, or add the configuration manually for other clients
+- in the **existing-project** path, run `ig ai-config` to write MCP configuration for your selected clients and copy the Agent Skills automatically
 
 In all cases, once the MCP servers are connected and visible in your AI client, the assistant can keep working in the same session.
 
@@ -382,7 +382,7 @@ The following setup scenarios show when to use each starting point.
 
 ### CLI-first setup
 
-Create the project with Ignite UI CLI first when you want the fastest guided setup and want `.vscode/mcp.json` generated for you automatically.
+Create the project with Ignite UI CLI first when you want the fastest guided setup. `ig new` prompts you to select which AI clients to configure for MCP and which agents to set up skill files for.
 
 Example scenarios:
 
@@ -425,9 +425,9 @@ Reload the workspace, reopen the editor, or restart the AI client. Some clients 
 
 Verify that the configuration content matches the examples exactly, including key names and argument order.
 
-**The project was created, but the MCP configuration is only available for VS Code**
+**The project was created, but MCP is not configured for one of your AI clients**
 
-Ignite UI CLI writes `.vscode/mcp.json` for the CLI-first path. If you are using Cursor, Claude Desktop, Claude Code, JetBrains, GitHub, or another MCP client, copy the same server entries into that client's configuration format and location.
+`ig new` prompts you to select which clients to configure. If you skipped a client during project creation, run `ig ai-config` and select the missing clients when prompted.
 
 **The assistant is working in the wrong folder or cannot find the project files**
 

--- a/doc/en/components/ai/skills.md
+++ b/doc/en/components/ai/skills.md
@@ -214,7 +214,7 @@ Use one of the options below to download and place the skill files into the appr
 
 ### **Option A - Use the Ignite UI CLI**
 
-The `ai-config` command configures MCP servers, copies framework-specific skill files into each agent's skills directory, and sets up instruction files — all in a single step. Use `--assistants` to choose which coding assistants receive MCP config and `--agents` to choose which agents receive skill files. Existing files are only updated if their content has changed. If no parameters are provided, the command enters interactive mode, prompting you to select assistants and agents. For available options, refer to the table below.
+The `ai-config` command configures MCP servers, copies framework-specific skill files into each agent's skills directory, and sets up instruction files - all in a single step. Use `--assistants` to choose which coding assistants receive MCP config and `--agents` to choose which agents receive skill files. Existing files are only updated if their content has changed. If no parameters are provided, the command enters interactive mode, prompting you to select assistants and agents. For available options, refer to the table below.
 
 ```bash
 ig ai-config --assistants generic --agents claude
@@ -231,6 +231,11 @@ ig ai-config --assistants generic vscode --agents claude copilot cursor
 | `--assistants` | `generic`, `vscode`, `cursor`, `gemini`, `junie`, `none` | Prompted interactively |
 | `--agents` | `generic`, `claude`, `copilot`, `cursor`, `codex`, `windsurf`, `gemini`, `junie`, `none` | Prompted interactively |
 
+<!-- Blazor -->
+> [!NOTE]
+> For Blazor, `ai-config` detects your project via `.csproj` or `.sln`. The `IgniteUI.Blazor` NuGet package does not need to be installed. If no project file is found, the command prompts you to select a framework.
+<!-- end: Blazor -->
+
 <!-- Angular -->
 
 **Using Angular Schematics:**
@@ -243,6 +248,98 @@ This also registers the `@angular/cli` MCP server alongside the Ignite UI server
 
 <!-- end: Angular -->
 
+<!-- Angular, React, WebComponents -->
+
+> [!NOTE]
+> If you installed {ProductName} manually and want to copy skills without running `ai-config`, the skill files are also available under `node_modules`. To copy them into your project (e.g. into `.agents/skills/`), run:
+
+**macOS / Linux / Windows (PowerShell)**
+
+```bash
+cp -r node_modules/{PackageCommon}/skills/. .agents/skills/
+```
+
+**Windows (Command Prompt)**
+
+```cmd
+robocopy node_modules\{PackageCommon}\skills .agents\skills /E
+```
+
+Or copy individual skill directories as needed:
+
+**macOS / Linux / Windows (PowerShell)**
+
+<!-- WebComponents -->
+
+```bash
+cp -r node_modules/{PackageCommon}/skills/igniteui-wc-choose-components .agents/skills/
+cp -r node_modules/{PackageCommon}/skills/igniteui-wc-customize-component-theme .agents/skills/
+cp -r node_modules/{PackageCommon}/skills/igniteui-wc-optimize-bundle-size .agents/skills/
+cp -r node_modules/{PackageCommon}/skills/igniteui-wc-integrate-with-framework .agents/skills/
+cp -r node_modules/{PackageCommon}/skills/igniteui-wc-generate-from-image-design .agents/skills/
+```
+
+<!-- end: WebComponents -->
+
+<!-- React -->
+
+```bash
+cp -r node_modules/{PackageCommon}/skills/igniteui-react-components .agents/skills/
+cp -r node_modules/{PackageCommon}/skills/igniteui-react-customize-theme .agents/skills/
+cp -r node_modules/{PackageCommon}/skills/igniteui-react-optimize-bundle-size .agents/skills/
+cp -r node_modules/{PackageCommon}/skills/igniteui-react-generate-from-image-design .agents/skills/
+```
+
+<!-- end: React -->
+
+<!-- Angular -->
+
+```bash
+cp -r node_modules/{PackageCommon}/skills/igniteui-angular-components .agents/skills/
+cp -r node_modules/{PackageCommon}/skills/igniteui-angular-grids .agents/skills/
+cp -r node_modules/{PackageCommon}/skills/igniteui-angular-theming .agents/skills/
+cp -r node_modules/{PackageCommon}/skills/igniteui-angular-generate-from-image-design .agents/skills/
+```
+
+<!-- end: Angular -->
+
+**Windows (Command Prompt)**
+
+<!-- WebComponents -->
+
+```cmd
+robocopy node_modules\{PackageCommon}\skills\igniteui-wc-choose-components .agents\skills\igniteui-wc-choose-components /E
+robocopy node_modules\{PackageCommon}\skills\igniteui-wc-customize-component-theme .agents\skills\igniteui-wc-customize-component-theme /E
+robocopy node_modules\{PackageCommon}\skills\igniteui-wc-optimize-bundle-size .agents\skills\igniteui-wc-optimize-bundle-size /E
+robocopy node_modules\{PackageCommon}\skills\igniteui-wc-integrate-with-framework .agents\skills\igniteui-wc-integrate-with-framework /E
+robocopy node_modules\{PackageCommon}\skills\igniteui-wc-generate-from-image-design .agents\skills\igniteui-wc-generate-from-image-design /E
+```
+
+<!-- end: WebComponents -->
+
+<!-- React -->
+
+```cmd
+robocopy node_modules\{PackageCommon}\skills\igniteui-react-components .agents\skills\igniteui-react-components /E
+robocopy node_modules\{PackageCommon}\skills\igniteui-react-customize-theme .agents\skills\igniteui-react-customize-theme /E
+robocopy node_modules\{PackageCommon}\skills\igniteui-react-optimize-bundle-size .agents\skills\igniteui-react-optimize-bundle-size /E
+robocopy node_modules\{PackageCommon}\skills\igniteui-react-generate-from-image-design .agents\skills\igniteui-react-generate-from-image-design /E
+```
+
+<!-- end: React -->
+
+<!-- Angular -->
+
+```cmd
+robocopy node_modules\{PackageCommon}\skills\igniteui-angular-components .agents\skills\igniteui-angular-components /E
+robocopy node_modules\{PackageCommon}\skills\igniteui-angular-grids .agents\skills\igniteui-angular-grids /E
+robocopy node_modules\{PackageCommon}\skills\igniteui-angular-theming .agents\skills\igniteui-angular-theming /E
+robocopy node_modules\{PackageCommon}\skills\igniteui-angular-generate-from-image-design .agents\skills\igniteui-angular-generate-from-image-design /E
+```
+
+<!-- end: Angular -->
+
+<!-- end: Angular, React, WebComponents -->
 
 ### **Option B - Use the `GitHub CLI`**
 
@@ -312,116 +409,6 @@ gh skill update IgniteUI/igniteui-react
 
 ```bash
 gh skill update IgniteUI/igniteui-blazor
-```
-
-<!-- end: Blazor -->
-
-If {ProductName} is already installed in your project, the skill files are available under `node_modules`. To copy them into your project (e.g. into `.agents/skills/`), run:
-
-**macOS / Linux / Windows (PowerShell)**
-
-```bash
-cp -r node_modules/{PackageCommon}/skills/. .agents/skills/
-```
-
-**Windows (Command Prompt)**
-
-```cmd
-robocopy node_modules\{PackageCommon}\skills .agents\skills /E
-```
-
-Or copy individual skill directories as needed:
-
-**macOS / Linux / Windows (PowerShell)**
-
-<!-- WebComponents -->
-
-```bash
-cp -r node_modules/{PackageCommon}/skills/igniteui-wc-choose-components .agents/skills/
-cp -r node_modules/{PackageCommon}/skills/igniteui-wc-customize-component-theme .agents/skills/
-cp -r node_modules/{PackageCommon}/skills/igniteui-wc-optimize-bundle-size .agents/skills/
-cp -r node_modules/{PackageCommon}/skills/igniteui-wc-integrate-with-framework .agents/skills/
-cp -r node_modules/{PackageCommon}/skills/igniteui-wc-generate-from-image-design .agents/skills/
-```
-
-<!-- end: WebComponents -->
-
-<!-- React -->
-
-```bash
-cp -r node_modules/{PackageCommon}/skills/igniteui-react-components .agents/skills/
-cp -r node_modules/{PackageCommon}/skills/igniteui-react-customize-theme .agents/skills/
-cp -r node_modules/{PackageCommon}/skills/igniteui-react-optimize-bundle-size .agents/skills/
-cp -r node_modules/{PackageCommon}/skills/igniteui-react-generate-from-image-design .agents/skills/
-```
-
-<!-- end: React -->
-
-<!-- Angular -->
-
-```bash
-cp -r node_modules/{PackageCommon}/skills/igniteui-angular-components .agents/skills/
-cp -r node_modules/{PackageCommon}/skills/igniteui-angular-grids .agents/skills/
-cp -r node_modules/{PackageCommon}/skills/igniteui-angular-theming .agents/skills/
-cp -r node_modules/{PackageCommon}/skills/igniteui-angular-generate-from-image-design .agents/skills/
-```
-
-<!-- end: Angular -->
-
-<!-- Blazor -->
-
-```bash
-cp -r node_modules/{PackageCommon}/skills/igniteui-blazor-components .agents/skills/
-cp -r node_modules/{PackageCommon}/skills/igniteui-blazor-grids .agents/skills/
-cp -r node_modules/{PackageCommon}/skills/igniteui-blazor-theming .agents/skills/
-cp -r node_modules/{PackageCommon}/skills/igniteui-blazor-generate-from-image-design .agents/skills/
-```
-
-<!-- end: Blazor -->
-
-**Windows (Command Prompt)**
-
-<!-- WebComponents -->
-
-```cmd
-robocopy node_modules\{PackageCommon}\skills\igniteui-wc-choose-components .agents\skills\igniteui-wc-choose-components /E
-robocopy node_modules\{PackageCommon}\skills\igniteui-wc-customize-component-theme .agents\skills\igniteui-wc-customize-component-theme /E
-robocopy node_modules\{PackageCommon}\skills\igniteui-wc-optimize-bundle-size .agents\skills\igniteui-wc-optimize-bundle-size /E
-robocopy node_modules\{PackageCommon}\skills\igniteui-wc-integrate-with-framework .agents\skills\igniteui-wc-integrate-with-framework /E
-robocopy node_modules\{PackageCommon}\skills\igniteui-wc-generate-from-image-design .agents\skills\igniteui-wc-generate-from-image-design /E
-```
-
-<!-- end: WebComponents -->
-
-<!-- React -->
-
-```cmd
-robocopy node_modules\{PackageCommon}\skills\igniteui-react-components .agents\skills\igniteui-react-components /E
-robocopy node_modules\{PackageCommon}\skills\igniteui-react-customize-theme .agents\skills\igniteui-react-customize-theme /E
-robocopy node_modules\{PackageCommon}\skills\igniteui-react-optimize-bundle-size .agents\skills\igniteui-react-optimize-bundle-size /E
-robocopy node_modules\{PackageCommon}\skills\igniteui-react-generate-from-image-design .agents\skills\igniteui-react-generate-from-image-design /E
-```
-
-<!-- end: React -->
-
-<!-- Angular -->
-
-```cmd
-robocopy node_modules\{PackageCommon}\skills\igniteui-angular-components .agents\skills\igniteui-angular-components /E
-robocopy node_modules\{PackageCommon}\skills\igniteui-angular-grids .agents\skills\igniteui-angular-grids /E
-robocopy node_modules\{PackageCommon}\skills\igniteui-angular-theming .agents\skills\igniteui-angular-theming /E
-robocopy node_modules\{PackageCommon}\skills\igniteui-angular-generate-from-image-design .agents\skills\igniteui-angular-generate-from-image-design /E
-```
-
-<!-- end: Angular -->
-
-<!-- Blazor -->
-
-```cmd
-robocopy node_modules\{PackageCommon}\skills\igniteui-blazor-components .agents\skills\igniteui-blazor-components /E
-robocopy node_modules\{PackageCommon}\skills\igniteui-blazor-grids .agents\skills\igniteui-blazor-grids /E
-robocopy node_modules\{PackageCommon}\skills\igniteui-blazor-theming .agents\skills\igniteui-blazor-theming /E
-robocopy node_modules\{PackageCommon}\skills\igniteui-blazor-generate-from-image-design .agents\skills\igniteui-blazor-generate-from-image-design /E
 ```
 
 <!-- end: Blazor -->
@@ -533,9 +520,21 @@ Once installed, the skill files are available in the respective location and wil
 
 The `skills` CLI is an interactive tool that downloads and installs skills directly into your project. Run the following command in your project root:
 
+<!-- Angular, React, WebComponents -->
+
 ```bash
 npx skills add IgniteUI/{PackageCommon}
 ```
+
+<!-- end: Angular, React, WebComponents -->
+
+<!-- Blazor -->
+
+```bash
+npx skills add IgniteUI/igniteui-blazor
+```
+
+<!-- end: Blazor -->
 
 The CLI will guide you through a series of prompts to:
 
@@ -545,7 +544,13 @@ The CLI will guide you through a series of prompts to:
 
 Once complete, the skills are ready to use - no manual file copying required.
 
+<!-- Angular, React, WebComponents -->
 > **Note:** Requires Node.js and an internet connection. The command fetches the latest skill files from the [IgniteUI/{PackageCommon}]({GithubLink}) repository.
+<!-- end: Angular, React, WebComponents -->
+
+<!-- Blazor -->
+> **Note:** Requires Node.js and an internet connection. The command fetches the latest skill files from the [IgniteUI/igniteui-blazor]({GithubLink}) repository.
+<!-- end: Blazor -->
 
 ---
 

--- a/doc/en/components/ai/theming-mcp.md
+++ b/doc/en/components/ai/theming-mcp.md
@@ -18,7 +18,7 @@ mentionedTypes: []
 
 The Ignite UI Theming MCP server gives AI assistants the knowledge and tools to produce accurate theming code, including palettes with proper shade generation, typography, elevations, component design token overrides, and more.
 
-The server supports all four Ignite UI design systems (**Material**, **Bootstrap**, **Fluent**, and **Indigo**) in both light and dark variants. While this guide focuses on {Platform}, the MCP server also works with all Ignite UI component libraries from Infragistics. The `detect_platform` tool reads your `package.json` and selects the correct import paths and selectors automatically.
+The server supports all four Ignite UI design systems (**Material**, **Bootstrap**, **Fluent**, and **Indigo**) in both light and dark variants. While this guide focuses on {Platform}, the MCP server also works with all Ignite UI component libraries from Infragistics. The `detect_platform` tool identifies the project framework and selects the correct import paths and selectors automatically. For Blazor projects, which have no `package.json`, it returns `generic` - tell the AI explicitly: _"Use the Blazor platform."_
 
 Most tools can produce either **Sass** or **CSS** output. Sass output is the default and integrates with the `igniteui-theming` Sass module. CSS output generates ready-to-use CSS custom properties and can be used **without a local Sass toolchain** - the server compiles it for you.
 
@@ -45,18 +45,39 @@ For a concrete combined workflow after setup, see [Build an App End-to-End with 
 Before configuring the MCP server, make sure you have:
 
 - **Node.js** (v18 or later) installed. This provides the `npx` command used to launch the server.
-- A project with an **Ignite UI package** listed as a dependency in `package.json`.
+
+- <!-- Angular, React, WebComponents -->
+A project with an **Ignite UI package** listed as a dependency in `package.json`.
+<!-- end: Angular, React, WebComponents -->
+
+<!-- Blazor -->
+A project with the **`IgniteUI.Blazor`** NuGet package installed.
+<!-- end: Blazor -->
+
 - An **AI client with MCP support** - for example, VS Code with GitHub Copilot, Cursor, Claude Desktop, Claude Code, or a JetBrains IDE with the AI Assistant plugin.
 
+<!-- Angular, React, WebComponents -->
 If you do not have Ignite UI Theming installed yet, run:
 
 ```bash
 npm install igniteui-theming
 ```
+<!-- end: Angular, React, WebComponents -->
+
+<!-- Blazor -->
+> [!NOTE]
+> The Theming MCP server is an npm package launched directly via `npx` - no local npm install is required in your Blazor project. `npx -y` fetches it from the npm registry on first use and caches it automatically.
+<!-- end: Blazor -->
 
 ## Setup
 
-The MCP server is bundled with the `igniteui-theming` package and launched via `npx`. No separate installation is needed beyond having an Ignite UI package already in your project.
+<!-- Angular, React, WebComponents -->
+The MCP server is bundled with the `igniteui-theming` npm package and launched via `npx`. No separate installation is needed beyond having an Ignite UI package already in your project.
+<!-- end: Angular, React, WebComponents -->
+
+<!-- Blazor -->
+The MCP server is launched via `npx` directly from the npm registry. It is not bundled with the `IgniteUI.Blazor` NuGet package - `npx -y` fetches and caches it automatically on first use.
+<!-- end: Blazor -->
 
 The canonical launch command is:
 
@@ -249,7 +270,7 @@ Here is a brief overview of each tool:
 
 | Tool | Description |
 |------|-------------|
-| `detect_platform` | Reads `package.json` and identifies whether the project uses Ignite UI for Angular, Web Components, React, or Blazor. Selects the correct import paths and component selectors for all subsequent tools. |
+| `detect_platform` | Identifies the project framework and selects the correct import paths and selectors. For Angular, React, and Web Components projects, reads `package.json`. For Blazor projects, which do not have a `package.json`, returns `generic` - tell the AI explicitly: _"Use the Blazor platform."_ |
 | `create_palette` | Generates a color palette with automatic shade variants (50-900, A100-A700) from your base brand colors. Accepts an `output` parameter (`sass` or `css`) and a `designSystem` to select the schema. |
 | `create_custom_palette` | Fine-grained palette creation. Specify exact hex values for every shade when automatic generation is not suitable. |
 | `create_typography` | Sets up a font family and type scale for a given design system. |
@@ -325,6 +346,14 @@ $my-palette: palette(
 ```
 <!-- end: React, WebComponents -->
 
+<!-- Blazor -->
+The Theming MCP generates **CSS custom properties** for Blazor projects. Tell the AI explicitly to use the Blazor platform and request CSS output:
+
+> _"Create a complete Material Design light theme for my Blazor app with primary #2563eb and secondary #f97316. Use the Blazor platform and generate CSS output."_
+
+Apply the generated CSS in your `wwwroot/css/app.css`.
+<!-- end: Blazor -->
+
 ### Dark Mode Variant
 
 > _"I need a dark mode version of my existing theme. Keep the same primary blue but use a dark surface #121212."_
@@ -351,7 +380,17 @@ The AI will call `set_spacing` scoped to the calendar component and `set_size` a
 
 **Platform not detected**
 
-If `detect_platform` returns `null` or `generic`, make sure your `package.json` lists an Ignite UI package (e.g., `{PackageCommon}`) as a dependency. You can also tell the AI explicitly: _"Use the {Platform} platform."_
+<!-- Angular, React, WebComponents -->
+If `detect_platform` returns `null` or `generic`, make sure your `package.json` lists an Ignite UI package (e.g., `{PackageCommon}`) as a dependency.
+<!-- end: Angular, React, WebComponents -->
+
+<!-- Blazor -->
+Blazor projects do not have a `package.json`, so `detect_platform` will always return `generic`. Tell the AI explicitly: _"Use the Blazor platform."_
+<!-- end: Blazor --> 
+
+<!-- Angular, React, WebComponents -->
+You can also tell the AI explicitly: _"Use the {Platform} platform."_
+<!-- end: Angular, React, WebComponents -->
 
 **Luminance warning on colors**
 

--- a/doc/en/components/ai/theming-mcp.md
+++ b/doc/en/components/ai/theming-mcp.md
@@ -46,7 +46,7 @@ Before configuring the MCP server, make sure you have:
 
 - **Node.js** (v18 or later) installed. This provides the `npx` command used to launch the server.
 
-- <!-- Angular, React, WebComponents -->
+<!-- Angular, React, WebComponents -->
 A project with an **Ignite UI package** listed as a dependency in `package.json`.
 <!-- end: Angular, React, WebComponents -->
 

--- a/doc/en/components/ai/theming-mcp.md
+++ b/doc/en/components/ai/theming-mcp.md
@@ -46,12 +46,12 @@ Before configuring the MCP server, make sure you have:
 
 - **Node.js** (v18 or later) installed. This provides the `npx` command used to launch the server.
 
-- <!-- Angular, React, WebComponents -->
-A project with an **Ignite UI package** listed as a dependency in `package.json`.
+<!-- Angular, React, WebComponents -->
+- A project with an **Ignite UI package** listed as a dependency in `package.json`.
 <!-- end: Angular, React, WebComponents -->
 
 <!-- Blazor -->
-A project with the **`IgniteUI.Blazor`** NuGet package installed.
+- A project with the **`IgniteUI.Blazor`** NuGet package installed.
 <!-- end: Blazor -->
 
 - An **AI client with MCP support** - for example, VS Code with GitHub Copilot, Cursor, Claude Desktop, Claude Code, or a JetBrains IDE with the AI Assistant plugin.


### PR DESCRIPTION
Fixes several inaccuracies and gaps across the AI toolchain documentation:

`ai-assisted-development-overview.md` 
`skills.md`
`theming-mcp.md
`